### PR TITLE
fixing issues with some results being None

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - pip install ".[all]"
 
 script:
-  - for i in {1..10}; do pytest -vs pydra; done;
+  - for i in {1..10}; do pytest -vs pydra/engine/tests/test_workflow.py; done;
   - py.test -vs -n auto --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - pip install ".[all]"
 
 script:
+  - do i in {1..10}; do pytest -vs pydra; done;
   - py.test -vs -n auto --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - pip install ".[all]"
 
 script:
-  - do i in {1..10}; do pytest -vs pydra; done;
+  - for i in {1..10}; do pytest -vs pydra; done;
   - py.test -vs -n auto --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra
 
 after_script:

--- a/pydra/__about__.py
+++ b/pydra/__about__.py
@@ -35,7 +35,6 @@ first-class operations. It forms the core of the Nipype 2.0 ecosystem.
 # versions
 NETWORKX_MIN_VERSION = "1.9"
 PYTEST_MIN_VERSION = "4.4.0"
-
 __packagename__ = "pydra"
 __author__ = __maintainer__ = "nipype developers"
 __email__ = "neuroimaging@python.org"
@@ -50,8 +49,10 @@ DOWNLOAD_URL = "http://github.com/nipype/{name}/archives/{ver}.tar.gz".format(
 )
 PLATFORMS = "OS Independent"
 MAJOR = __version__.split(".")[0]
-MINOR = __version__.split(".")[1]
-MICRO = __version__.replace("-", ".").split(".")[2]
+if len(__version__.split(".")) > 1:
+    MINOR = __version__.split(".")[1]
+if len(__version__.split(".")) > 2:
+    MICRO = __version__.replace("-", ".").split(".")[2]
 ISRELEASE = (
     len(__version__.replace("-", ".").split(".")) == 3
     or "post" in __version__.replace("-", ".").split(".")[-1]

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -438,6 +438,8 @@ class TaskBase:
             combined_results.append([])
             for ind in ind_l:
                 result = load_result(self.results_dict[ind][1], self.cache_locations)
+                if result is None:
+                    return None
                 combined_results[gr].append(result)
         return combined_results
 
@@ -459,6 +461,8 @@ class TaskBase:
                         result = load_result(
                             self.results_dict[ii][1], self.cache_locations
                         )
+                        if result is None:
+                            return None
                         results.append(result)
                     return results
             else:  # state_index is not None

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -57,9 +57,10 @@ class Submitter:
         task_futures = set()
         while not wf.done:
             remaining_tasks, tasks = await get_runnable_tasks(wf.graph, remaining_tasks)
-            if not tasks and not task_futures:
-                breakpoint()
-                raise Exception("Nothing queued or todo - something went wrong")
+            # dj: i actually think that this is ok if tasks is empty...
+            # if not tasks and not task_futures:
+            #     breakpoint()
+            #     raise Exception("Nothing queued or todo - something went wrong")
             for task in tasks:
                 # grab inputs if needed
                 logger.debug(f"Retrieving inputs for {task}")


### PR DESCRIPTION
I believe this version is working (I check all workflow tests couple hundreds times within docker, I also added to travis a loop to run tests 10 times).

One problem was in `result`: if results were within a list, the list was returned even if some elements were `None`. I changed, so whenever any element is `None`, the method returns `None`.

The second problem was that sometimes `get_runnable_tasks` returns an empty list of tasks ready to run even if `remaining_tasks` is not empty. I've started adding some "fixes", but at the end I realized that the exception should not be raised. I think it's fine if a task that waits for other tasks is not ready to run, even if the previous tasks were already removed from the list. Let me know if you agree with it, for now I just commented this part.

Also I edited slightly the version format in `__about__`