### PR TITLE
node/task tests and adding cache_locations to __call__

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -700,6 +700,7 @@ class Workflow(TaskBase):
             raise Exception("Submitter should already be set.")
         # at this point Workflow is stateless so this should be fine
         nwf = await submitter.submit(self, return_task=True)
+        # TODO: check if needed
         self.__dict__.update(nwf.__dict__)
 
     def set_output(self, connections):

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -700,7 +700,7 @@ class Workflow(TaskBase):
             raise Exception("Submitter should already be set.")
         # at this point Workflow is stateless so this should be fine
         nwf = await submitter.submit(self, return_task=True)
-        # TODO: check if needed
+        # TODO: check if this might be done differently
         self.__dict__.update(nwf.__dict__)
 
     def set_output(self, connections):

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -26,7 +26,9 @@ class Submitter:
             raise Exception("plugin {} not available".format(self.plugin))
         self.worker.loop = self.loop
 
-    def __call__(self, runnable):
+    def __call__(self, runnable, cache_locations=None):
+        if cache_locations is not None:
+            runnable.cache_locations = cache_locations
         if is_workflow(runnable):
             runnable.submit_async(self)
         else:

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -55,7 +55,6 @@ def fun_div(a, b):
 # Tests for tasks initializations
 
 
-@pytest.mark.xfail(reason="WIP, taks doesnt work")
 def test_task_init_1():
     """ task with mandatory arguments only"""
     nn = fun_addtwo()
@@ -64,13 +63,11 @@ def test_task_init_1():
     assert hasattr(nn, "__call__")
 
 
-@pytest.mark.xfail(reason="WIP, taks doesnt work")
 def test_task_init_1a():
     with pytest.raises(TypeError):
         fun_addtwo("NA")
 
 
-@pytest.mark.xfail(reason="WIP, taks doesnt work")
 def test_task_init_2():
     """ task with a name and inputs"""
     nn = fun_addtwo(name="NA", a=3)
@@ -79,7 +76,6 @@ def test_task_init_2():
     assert nn.state is None
 
 
-@pytest.mark.xfail(reason="WIP: state doesnt work yet")
 @pytest.mark.parametrize(
     "splitter, state_splitter, state_rpn, states_ind, states_val",
     [("a", "NA.a", ["NA.a"], [{"NA.a": 0}, {"NA.a": 1}], [{"NA.a": 3}, {"NA.a": 5}])],
@@ -97,7 +93,6 @@ def test_task_init_3(splitter, state_splitter, state_rpn, states_ind, states_val
     assert nn.state.states_val == states_val
 
 
-@pytest.mark.xfail(reason="WIP: state doesnt work yet")
 @pytest.mark.parametrize(
     "splitter, state_splitter, state_rpn, states_ind, states_val",
     [
@@ -141,7 +136,6 @@ def test_task_init_3a(splitter, state_splitter, state_rpn, states_ind, states_va
     assert nn.state.states_val == states_val
 
 
-@pytest.mark.xfail(reason="WIP: state doesnt work yet")
 def test_task_init_4():
     """ task with interface and inputs. splitter set using split method"""
     nn = fun_addtwo(name="NA", a=[3, 5])
@@ -156,7 +150,6 @@ def test_task_init_4():
     nn.state.states_val = [{"NA.a": 3}, {"NA.a": 5}]
 
 
-@pytest.mark.xfail(reason="WIP: state doesnt work yet")
 def test_task_init_4a():
     """ task with a splitter and inputs set in the split method"""
     nn = fun_addtwo(name="NA")
@@ -171,7 +164,6 @@ def test_task_init_4a():
     nn.state.states_val = [{"NA.a": 3}, {"NA.a": 5}]
 
 
-@pytest.mark.xfail(reason="WIP: state doesnt work yet")
 def test_task_init_4b():
     """ trying to set splitter twice"""
     nn = fun_addtwo(name="NA").split(splitter="a", a=[3, 5])
@@ -180,7 +172,6 @@ def test_task_init_4b():
     assert str(excinfo.value) == "splitter has been already set"
 
 
-@pytest.mark.xfail(reason="WIP, taks doesnt work")
 def test_task_error():
     func = fun_div(name="div", a=1, b=0)
     with pytest.raises(ZeroDivisionError):
@@ -191,7 +182,6 @@ def test_task_error():
 # Tests for tasks without state (i.e. no splitter)
 
 
-@pytest.mark.xfail(reason="WIP, taks doesnt work")
 @pytest.mark.parametrize("plugin", Plugins)
 def test_task_nostate_1(plugin):
     """ task without splitter"""
@@ -207,7 +197,6 @@ def test_task_nostate_1(plugin):
     assert results.output.out == 5
 
 
-@pytest.mark.xfail(reason="WIP, taks doesnt work")
 @pytest.mark.parametrize("plugin", Plugins)
 def test_task_nostate_2(plugin):
     """ task with a list as an input, but no splitter"""
@@ -227,7 +216,6 @@ def test_task_nostate_2(plugin):
 # Testing caching for tasks without states
 
 
-@pytest.mark.xfail(reason="WIP, taks doesnt work")
 @pytest.mark.parametrize("plugin", Plugins)
 def test_task_nostate_cachedir(plugin, tmpdir):
     """ task with provided cache_dir using pytest tmpdir"""
@@ -244,7 +232,6 @@ def test_task_nostate_cachedir(plugin, tmpdir):
     assert results.output.out == 5
 
 
-@pytest.mark.xfail(reason="WIP, taks doesnt work")
 @pytest.mark.parametrize("plugin", Plugins)
 def test_task_nostate_cachedir_relativepath(tmpdir, plugin):
     """ task with provided cache_dir as relative path"""
@@ -264,7 +251,6 @@ def test_task_nostate_cachedir_relativepath(tmpdir, plugin):
     shutil.rmtree(cache_dir)
 
 
-@pytest.mark.xfail(reason="WIP, taks doesnt work")
 @pytest.mark.parametrize("plugin", Plugins)
 def test_task_nostate_cachelocations(plugin, tmpdir):
     """
@@ -291,13 +277,13 @@ def test_task_nostate_cachelocations(plugin, tmpdir):
     assert not nn2.output_dir.exists()
 
 
-@pytest.mark.xfail(reason="WIP, taks doesnt work")
 @pytest.mark.parametrize("plugin", Plugins)
 def test_task_nostate_cachelocations_updated(plugin, tmpdir):
     """
     Two identical tasks with provided cache_dir;
-    the second task has cache_locations in init that is later overwritten in run;
-    the cache_locations from run doesn't exist so the second task should run again
+    the second task has cache_locations in init,
+     that is later overwritten in Submitter.__call__;
+    the cache_locations passed to call doesn't exist so the second task should run again
     """
     cache_dir = tmpdir.mkdir("test_task_nostate")
     cache_dir1 = tmpdir.mkdir("test_task_nostate1")
@@ -308,6 +294,7 @@ def test_task_nostate_cachelocations_updated(plugin, tmpdir):
         sub(nn)
 
     nn2 = fun_addtwo(name="NA", a=3, cache_dir=cache_dir2, cache_locations=cache_dir)
+    # updating cache location to non-existing dir
     with Submitter(plugin=plugin) as sub:
         sub(nn2, cache_locations=cache_dir1)
 
@@ -323,7 +310,6 @@ def test_task_nostate_cachelocations_updated(plugin, tmpdir):
 # Tests for tasks with states (i.e. with splitter)
 
 
-@pytest.mark.xfail(reason="WIP: state doesnt work yet")
 @pytest.mark.parametrize("plugin", Plugins)
 def test_task_state_1(plugin):
     """ task with the simplest splitter"""
@@ -343,7 +329,6 @@ def test_task_state_1(plugin):
         assert results[i].output.out == res[1]
 
 
-@pytest.mark.xfail(reason="WIP: state doesnt work yet")
 @pytest.mark.parametrize("plugin", Plugins)
 def test_task_state_1a(plugin):
     """ task with the simplest splitter (inputs set separately)"""
@@ -365,7 +350,6 @@ def test_task_state_1a(plugin):
         assert results[i].output.out == res[1]
 
 
-@pytest.mark.xfail(reason="WIP: state doesnt work yet")
 @pytest.mark.parametrize(
     "splitter, state_splitter, state_rpn, expected",
     [
@@ -409,7 +393,6 @@ def test_task_state_2(plugin, splitter, state_splitter, state_rpn, expected):
         assert results[i].output.out == res[1]
 
 
-@pytest.mark.xfail(reason="WIP: state doesnt work yet")
 @pytest.mark.parametrize("plugin", Plugins)
 def test_task_state_comb_1(plugin):
     """ task with the simplest splitter and combiner"""
@@ -438,7 +421,6 @@ def test_task_state_comb_1(plugin):
         assert combined_results[i] == res[1]
 
 
-@pytest.mark.xfail(reason="WIP: state doesnt work yet")
 @pytest.mark.parametrize(
     "splitter, combiner, state_splitter, state_rpn, state_combiner, state_combiner_all, "
     "state_splitter_final, state_rpn_final, expected",
@@ -544,7 +526,6 @@ def test_task_state_comb_2(
 # Testing caching for tasks with states
 
 
-@pytest.mark.xfail(reason="WIP: state doesnt work yet")
 @pytest.mark.parametrize("plugin", Plugins)
 def test_task_state_cachedir(plugin, tmpdir):
     """ task with a state and provided cache_dir using pytest tmpdir"""
@@ -564,7 +545,6 @@ def test_task_state_cachedir(plugin, tmpdir):
         assert results[i].output.out == res[1]
 
 
-@pytest.mark.xfail(reason="WIP: state doesnt work yet")
 @pytest.mark.xfail(reason="TODO: output_dir.exists check doesn't work when splitter")
 @pytest.mark.parametrize("plugin", Plugins)
 def test_task_state_cachelocations(plugin, tmpdir):
@@ -597,14 +577,14 @@ def test_task_state_cachelocations(plugin, tmpdir):
     assert not nn2.output_dir.exists()
 
 
-@pytest.mark.xfail(reason="WIP: state doesnt work yet")
 @pytest.mark.xfail(reason="TODO: output_dir.exists check doesn't work when splitter")
 @pytest.mark.parametrize("plugin", Plugins)
 def test_task_state_cachelocations_updated(plugin, tmpdir):
     """
     Two identical tasks with states and cache_dir;
-    the second task has cache_locations in init that is later overwritten in run;
-    the cache_locations from run doesn't exist so the second task should run again
+    the second task has cache_locations in init,
+     that is later overwritten in Submitter.__call__;
+    the cache_locations from call doesn't exist so the second task should run again
     """
     cache_dir = tmpdir.mkdir("test_task_nostate")
     cache_dir1 = tmpdir.mkdir("test_task_nostate1")

--- a/pydra/engine/workers.py
+++ b/pydra/engine/workers.py
@@ -79,9 +79,7 @@ class ConcurrentFuturesWorker(Worker):
         # wrap as asyncio task
         if not self.loop:
             raise Exception("No event loop available to submit tasks")
-        task = asyncio.create_task(
-            exec_as_coro(self.loop, self.pool, interface)
-        )
+        task = asyncio.create_task(exec_as_coro(self.loop, self.pool, interface))
         return task
 
     async def exec_as_coro(self, interface):  # sidx=None):
@@ -112,6 +110,10 @@ class ConcurrentFuturesWorker(Worker):
         except ValueError:
             # nothing pending!
             pending = set()
+        if done.union(pending) != futures:
+            raise Exception(
+                "all tasks from futures should be either in done or pending"
+            )
         logger.debug(f"Tasks finished: {len(done)}")
         return done, pending
 

--- a/pydra/engine/workers.py
+++ b/pydra/engine/workers.py
@@ -110,10 +110,10 @@ class ConcurrentFuturesWorker(Worker):
         except ValueError:
             # nothing pending!
             pending = set()
-        if done.union(pending) != futures:
-            raise Exception(
-                "all tasks from futures should be either in done or pending"
-            )
+
+        assert (
+            done.union(pending) == futures
+        ), "all tasks from futures should be either in done or pending"
         logger.debug(f"Tasks finished: {len(done)}")
         return done, pending
 


### PR DESCRIPTION
- removing xfail from task/node tests (there are still 2 tests that xfail, but that was before your changes, have to come back to this)

- we used to have an option to overwrite `cache_locations` when submitting, so I added a simple update to `Submitter.__call__` 