### PR TITLE
adding one more case to submit_from_call

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     -   id: black
 -   repo: https://github.com/codespell-project/codespell

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -46,8 +46,8 @@ class Submitter:
         This coroutine should only be called once per Submitter call,
         and serves as the bridge between sync/async lands.
 
-        There are 3 potential paths based on the type of runnable:
-
+        There are 4 potential paths based on the type of runnable:
+        0) Workflow has a different plugin than a submitter
         1) Workflow without State
         2) Task without State
         3) (Workflow or Task) with State
@@ -58,6 +58,10 @@ class Submitter:
         if is_workflow(runnable):
             # connect and calculate the checksum of the graph before running
             runnable._connect_and_propagate_to_tasks(override_task_caches=True)
+            # 0
+            if runnable.plugin and runnable.plugin != self.plugin:
+                # if workflow has a different plugin it's treated as a single element
+                await self.worker.run_el(runnable, rerun=rerun)
             # 1
             if runnable.state is None:
                 await runnable._run(self, rerun=rerun)

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -20,7 +20,7 @@ import uuid
 from datetime import datetime
 
 slurm_available = bool(shutil.which("sbatch"))
-sge_available = bool(shutil.which("qacct"))
+sge_available = bool(shutil.which("qsub"))
 
 
 @mark.task

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -20,7 +20,7 @@ import uuid
 from datetime import datetime
 
 slurm_available = bool(shutil.which("sbatch"))
-sge_available = bool(shutil.which("qsub"))
+sge_available = bool(shutil.which("qacct"))
 
 
 @mark.task


### PR DESCRIPTION
 I added one more case in `submit_from_call` one more case for situation when workflow has a different `plugin`. In that case we were using `self.worker.run_el(runnable, rerun=rerun)`. That was one of the case that was marked as "not tested", but I was wrong it was used in [one test](https://github.com/nipype/pydra/blob/master/pydra/engine/tests/test_submitter.py#L202)  where the workflow is run with `slurm` but tasks with `cf`.

I know it is not the most common case, but I believe at some point @satra and I thought that might be useful. (@satra -any new thoughts?)